### PR TITLE
No Longer Can Eat Cybernetic Implants

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -81,7 +81,7 @@
 	return ..()
 
 /obj/item/organ/internal/proc/prepare_eat()
-	if(robotic)
+	if(status == ORGAN_ROBOT)
 		return //no eating cybernetic implants!
 	var/obj/item/weapon/reagent_containers/food/snacks/organ/S = new
 	S.name = name


### PR DESCRIPTION
This makes is so you can no longer eat cybernetic implants improperly,
just because they are in organ code. Fixes the check that originally
made it so you couldn't eat them.

:cl: Twinmold
Fix: Fixes being able to eat cybernetic implants so you cannot eat
them/force feed them to people.
/:cl:
